### PR TITLE
Added flag to allow alsa to do software resampling if supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ var alsa = require('alsa'),
   format = alsa.FORMAT_S16_LE,          // PCM format (signed 16 bit LE int)
   access = alsa.ACCESS_RW_INTERLEAVED,  // Access mode
   latency = 500;                        // Desired latency in milliseconds
-
+  software_resampling = false           // If true and the alsa driver supports resampling, allow it to
+  
 // The Capture class is a stream.Readable subclass.
-var capture = new alsa.Capture(device, channels, rate, format, access, latency);
+var capture = new alsa.Capture(device, channels, rate, format, access, latency, software_resampling);
 capture.pipe(process.stdout);   // Treat it like any other readable stream.
 
 // The Playback class is a stream.Writable subclass.

--- a/pcm.cc
+++ b/pcm.cc
@@ -1,4 +1,5 @@
 #include "pcm.h"
+#include <stdio.h>
 
 using namespace alsa;
 
@@ -37,6 +38,7 @@ Handle<Value> Pcm::New(const Arguments& args) {
   args.This()->Set(String::NewSymbol("format"), args[2], ReadOnly);
   args.This()->Set(String::NewSymbol("access"), args[3], ReadOnly);
   args.This()->Set(String::NewSymbol("latency"), args[4], ReadOnly);
+  args.This()->Set(String::NewSymbol("software_resampling"), args[5], ReadOnly);
 
   return args.This();
 }
@@ -76,7 +78,8 @@ Handle<Value> Pcm::Open(const Arguments& args) {
   snd_pcm_format_t format = static_cast<snd_pcm_format_t>(args.Holder()->Get(String::NewSymbol("format"))->Int32Value());
   snd_pcm_access_t access = static_cast<snd_pcm_access_t>(args.Holder()->Get(String::NewSymbol("access"))->Int32Value());
   unsigned int latency = args.Holder()->Get(String::NewSymbol("latency"))->Uint32Value();
-  
+  unsigned int software_resampling = args.Holder()->Get(String::NewSymbol("software_resampling"))->BooleanValue();
+
   // device, stream
   String::Utf8Value device(args[0]->ToString());
   snd_pcm_stream_t stream = static_cast<snd_pcm_stream_t>(args[1]->Int32Value());
@@ -85,7 +88,7 @@ Handle<Value> Pcm::Open(const Arguments& args) {
   err = snd_pcm_open(&(pcm->handle), *device, stream, 0);
   COND_ERR_CALL(err < 0, callback, "Couldn't open");
 
-  err = snd_pcm_set_params(pcm->handle, format, access, channels, rate, 0, latency);
+  err = snd_pcm_set_params(pcm->handle, format, access, channels, rate, software_resampling, latency);
   COND_ERR_CALL(err < 0, callback, "Couldn't set parameters");
 
 #ifdef DEBUG

--- a/src/stream.coffee
+++ b/src/stream.coffee
@@ -3,9 +3,9 @@ alsa = require './constants'
 Pcm = require('../build/Release/alsa').Pcm
 
 class Capture extends stream.Readable
-  constructor: (@device = 'default', channels = 2, rate = 44100, format = alsa.FORMAT_S16_LE, access = alsa.ACCESS_RW_INTERLEAVED, latency = 500) ->
+  constructor: (@device = 'default', channels = 2, rate = 44100, format = alsa.FORMAT_S16_LE, access = alsa.ACCESS_RW_INTERLEAVED, latency = 500, software_resampling = false) ->
     stream.Readable.call this
-    @pcm = new Pcm channels, rate, format, access, (latency * 1000)
+    @pcm = new Pcm channels, rate, format, access, (latency * 1000), software_resampling
 
   _read: ->
     return false if @pcm.opened


### PR DESCRIPTION
This allows capturing streams of lower/higher sample rate than the hardware might support, for example pulling an 8K ulaw sample from a card that only supports 48k sampling.
The flag is by default off, and is optional, so existing code should work just fine.
